### PR TITLE
Missing exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ add_subdirectory(felspar-exceptions)
 To use add the `felspar-exceptions` and `felspar-test` libraries to your project and include the utility header:
 
 ```cpp
-#include <felspar/exception.hpp>
+#include <felspar/exceptions.hpp>
 ```
 
 For all of the exception types an extra source location can be explicitly provided to customise the captured source location:
@@ -83,7 +83,7 @@ Might be reported as:
 ## `felspar::stdexcept::overflow_error` and `felspar::stdexcept::underflow_error`
 
 ```cpp
-#include <felspar/exception.hpp> // convenience header
+#include <felspar/exceptions.hpp> // convenience header
 #include <felspar/exceptions/overflow_error.hpp> // specific header
 #include <felspar/exceptions/underflow_error.hpp> // specific header
 ```
@@ -140,7 +140,7 @@ As:
 ## `felspar::stdexcept::bad_alloc`
 
 ```cpp
-#include <felspar/exception.hpp> // convenience header
+#include <felspar/exceptions.hpp> // convenience header
 #include <felspar/exceptions/bad_alloc.hpp> // specific header
 ```
 

--- a/include/felspar/exceptions.hpp
+++ b/include/felspar/exceptions.hpp
@@ -3,6 +3,7 @@
 
 #include <felspar/exceptions/bad_alloc.hpp>
 #include <felspar/exceptions/exception.hpp>
+#include <felspar/exceptions/invalid_argument.hpp>
 #include <felspar/exceptions/length_error.hpp>
 #include <felspar/exceptions/logic_error.hpp>
 #include <felspar/exceptions/messaging_error.hpp>

--- a/include/felspar/exceptions.hpp
+++ b/include/felspar/exceptions.hpp
@@ -7,6 +7,7 @@
 #include <felspar/exceptions/length_error.hpp>
 #include <felspar/exceptions/logic_error.hpp>
 #include <felspar/exceptions/messaging_error.hpp>
+#include <felspar/exceptions/out_of_range.hpp>
 #include <felspar/exceptions/overflow_error.hpp>
 #include <felspar/exceptions/runtime_error.hpp>
 #include <felspar/exceptions/system_error.hpp>

--- a/include/felspar/exceptions.hpp
+++ b/include/felspar/exceptions.hpp
@@ -3,6 +3,7 @@
 
 #include <felspar/exceptions/bad_alloc.hpp>
 #include <felspar/exceptions/exception.hpp>
+#include <felspar/exceptions/domain_error.hpp>
 #include <felspar/exceptions/invalid_argument.hpp>
 #include <felspar/exceptions/length_error.hpp>
 #include <felspar/exceptions/logic_error.hpp>

--- a/include/felspar/exceptions/domain_error.hpp
+++ b/include/felspar/exceptions/domain_error.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+
+#include <felspar/exceptions/messaging_error.hpp>
+
+
+namespace felspar::stdexcept {
+
+
+    using domain_error = exceptions::messaging_error<std::domain_error>;
+
+
+}

--- a/include/felspar/exceptions/invalid_argument.hpp
+++ b/include/felspar/exceptions/invalid_argument.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+
+#include <felspar/exceptions/messaging_error.hpp>
+
+
+namespace felspar::stdexcept {
+
+
+    using invalid_argument = exceptions::messaging_error<std::invalid_argument>;
+
+
+}

--- a/include/felspar/exceptions/out_of_range.hpp
+++ b/include/felspar/exceptions/out_of_range.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+
+#include <felspar/exceptions/messaging_error.hpp>
+
+
+namespace felspar::stdexcept {
+
+
+    using out_of_range = exceptions::messaging_error<std::out_of_range>;
+
+
+}


### PR DESCRIPTION
Adds wrappers for a few more of the `std` exceptions. There are others not wrapped, but those seem unlikely to be in use in code outside the standard library implementation.